### PR TITLE
Improve 8D effect and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 8D Audio Converter
 
-This simple Flask web app converts uploaded audio files into an 8D version using [pydub](https://github.com/jiaaro/pydub).
+This simple Flask web app converts uploaded audio files into an 8D version using [pydub](https://github.com/jiaaro/pydub). The pan effect now uses a smooth sine wave so the audio moves naturally between ears. The web UI also shows a loading bar while processing and lets you choose how fast the audio rotates.
 
 ## Requirements
 
@@ -27,4 +27,4 @@ By default the server listens on `0.0.0.0:5000`. You can customize the host or p
 HOST=0.0.0.0 PORT=8080 python app.py
 ```
 
-Open the URL in a browser, upload an MP3 or WAV file, and download the generated 8D audio.
+Open the URL in a browser, upload an MP3 or WAV file, set a transition speed if desired, and download the generated 8D audio.

--- a/app.py
+++ b/app.py
@@ -1,13 +1,16 @@
 from flask import Flask, request, send_file, render_template_string, send_from_directory
 from pydub import AudioSegment
 import os
+import math
 
 app = Flask(__name__)
 UPLOAD_FOLDER = "."
+SEGMENT_MS = 100  # length of each audio segment for panning
 
 @app.route("/", methods=["GET", "POST"])
 def index():
     download_link = None
+    speed = request.form.get("speed", "5")
     if request.method == "POST":
         file = request.files["audio"]
         filename = file.filename
@@ -16,10 +19,17 @@ def index():
 
         audio = AudioSegment.from_file(filepath)
         audio_8d = AudioSegment.empty()
+        try:
+            speed_val = float(speed)
+            if speed_val <= 0:
+                speed_val = 5.0
+        except ValueError:
+            speed_val = 5.0
 
-        for i in range(0, len(audio), 200):
-            segment = audio[i:i+200]
-            pan = ((i // 200) % 40 - 20) / 20
+        for i in range(0, len(audio), SEGMENT_MS):
+            segment = audio[i:i+SEGMENT_MS]
+            t = i / 1000.0  # time in seconds
+            pan = math.sin(2 * math.pi * t / speed_val)
             audio_8d += segment.pan(pan)
 
         output_path = os.path.join(UPLOAD_FOLDER, f"8d_{filename}")
@@ -28,7 +38,7 @@ def index():
 
     with open("index.html") as f:
         html = f.read()
-    return render_template_string(html, download_link=download_link)
+    return render_template_string(html, download_link=download_link, speed=speed)
 
 @app.route("/download/<filename>")
 def download(filename):

--- a/index.html
+++ b/index.html
@@ -3,14 +3,26 @@
 <head>
   <title>8D Audio Converter</title>
   <link rel="stylesheet" href="/style.css">
+  <script>
+    function showProgress() {
+      document.getElementById('progress-container').style.display = 'block';
+    }
+  </script>
 </head>
 <body>
   <div class="container">
     <h1>🎧 8D Audio Converter</h1>
-    <form method="POST" enctype="multipart/form-data">
+    <form method="POST" enctype="multipart/form-data" onsubmit="showProgress()">
       <input type="file" name="audio" accept=".mp3,.wav" required>
+      <div class="speed-input">
+        <label for="speed">Transition speed (seconds)</label>
+        <input type="number" step="0.1" min="0.5" name="speed" id="speed" value="{{ speed or 5 }}">
+      </div>
       <button type="submit">Convert</button>
     </form>
+    <div id="progress-container">
+      <div id="progress-bar"></div>
+    </div>
     {% if download_link %}
       <p><a href="{{ download_link }}">⬇️ Download 8D Audio</a></p>
     {% endif %}

--- a/style.css
+++ b/style.css
@@ -20,3 +20,32 @@ button {
   color: #000;
   cursor: pointer;
 }
+.speed-input {
+  margin: 15px 0;
+}
+.speed-input label {
+  display: block;
+  margin-bottom: 5px;
+}
+
+#progress-container {
+  width: 100%;
+  background: #333;
+  height: 10px;
+  border-radius: 5px;
+  overflow: hidden;
+  margin-top: 20px;
+  display: none;
+}
+
+#progress-bar {
+  width: 0%;
+  height: 100%;
+  background: #00ffff;
+  animation: progress 2s linear infinite;
+}
+
+@keyframes progress {
+  0% { width: 0%; }
+  100% { width: 100%; }
+}


### PR DESCRIPTION
## Summary
- use smooth sine-wave panning to avoid hard jumps between ears
- allow user-defined transition speed
- show a simple loading bar while conversion runs
- add some basic styling tweaks

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68410a54b6e88332b980a16d44b923ac